### PR TITLE
SEO-455: log current cache state back to host app

### DIFF
--- a/lib/resty/cache.lua
+++ b/lib/resty/cache.lua
@@ -41,6 +41,7 @@ function _M.run(self)
     -- ngx.log(loglevel, "[LUA], cache key", key, ", ttl: ", ttl)
     -- stale time, need update the cache
     if ttl < stale then
+        ngx.var['http_x_cache'] = 'miss'
         if method == "POST" or method == "PUT" then ngx.req.read_body() end
         -- cache missing, no need to using srcache_fetch, go to backend server, and store new cache
         -- if redis server version is 2.8- can not return -2 !!!!!!
@@ -64,6 +65,8 @@ function _M.run(self)
                 ngx.timer.at(0, request, http, ngx.var.request_uri, self.cache_server_port, method, ngx.req.get_headers(), ngx.req.get_body_data(), self.cache_skip_fetch)
             end
         end
+    else
+        ngx.var['http_x_cache'] = 'hit'
     end
 end
 


### PR DESCRIPTION
As part of the background_cache process, it is important that we tell the host app whether we hit the cache or missed it.
